### PR TITLE
Remove use of `system-file{path,io}`

### DIFF
--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -47,8 +47,6 @@
 --
 --  "Control.Monad.Managed.Safe" provides `Managed` resources
 --
---  "Filesystem.Path.CurrentOS" provides `FilePath`-manipulation utilities
---
 --  Additionally, you might also want to import the following modules qualified:
 --
 --  * "Options.Applicative" from @optparse-applicative@ for command-line option
@@ -61,8 +59,6 @@
 --  * "Data.Text" (for `Text`-manipulation utilities)
 --
 --  * "Data.Text.IO" (for reading and writing `Text`)
---
---  * "Filesystem.Path.CurrentOS" (for the remaining `FilePath` utilities)
 
 module Turtle (
     -- * Modules
@@ -77,7 +73,8 @@ module Turtle (
     , module Control.Monad.IO.Class
     , module Data.Monoid
     , module Control.Monad.Managed
-    , module Filesystem.Path.CurrentOS
+    , module System.FilePath
+    , module Turtle.Internal
     , Fold(..)
     , FoldM(..)
     , Text
@@ -120,37 +117,30 @@ import Control.Monad
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Monoid (Monoid(..), (<>))
 import Data.String (IsString(..))
-import Filesystem.Path.CurrentOS
-    ( FilePath
-    , root
+import Control.Monad.Managed (Managed, managed, runManaged, with)
+import Control.Foldl (Fold(..), FoldM(..))
+import Data.Text (Text)
+import Data.Time (NominalDiffTime, UTCTime)
+import System.FilePath (FilePath, dropExtension, hasExtension, (</>), (<.>))
+import System.IO (Handle)
+import System.Exit (ExitCode(..))
+import Turtle.Internal
+    ( root
     , directory
-    , parent
     , filename
     , dirname
     , basename
     , absolute
     , relative
-    , (</>)
-    , commonPrefix
     , stripPrefix
-    , collapse
     , splitDirectories
     , extension
-    , hasExtension
-    , (<.>)
-    , dropExtension
     , splitExtension
     , toText
     , fromText
     , encodeString
     , decodeString
     )
-import Control.Monad.Managed (Managed, managed, runManaged, with)
-import Control.Foldl (Fold(..), FoldM(..))
-import Data.Text (Text)
-import Data.Time (NominalDiffTime, UTCTime)
-import System.IO (Handle)
-import System.Exit (ExitCode(..))
 import Prelude hiding (FilePath)
 
 #if __GLASGOW_HASKELL__ >= 710

--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -121,7 +121,18 @@ import Control.Monad.Managed (Managed, managed, runManaged, with)
 import Control.Foldl (Fold(..), FoldM(..))
 import Data.Text (Text)
 import Data.Time (NominalDiffTime, UTCTime)
-import System.FilePath (FilePath, dropExtension, hasExtension, (</>), (<.>))
+import System.FilePath
+    ( FilePath
+    , dropExtension
+    , hasExtension
+    , isAbsolute
+    , isRelative
+    , splitPath
+    , takeBaseName
+    , takeFileName
+    , (</>)
+    , (<.>)
+    )
 import System.IO (Handle)
 import System.Exit (ExitCode(..))
 import Turtle.Internal

--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -128,8 +128,6 @@ import System.FilePath
     , isAbsolute
     , isRelative
     , splitPath
-    , takeBaseName
-    , takeFileName
     , (</>)
     , (<.>)
     )

--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -136,6 +136,7 @@ import Turtle.Internal
     , splitDirectories
     , extension
     , splitExtension
+    , splitExtensions
     , toText
     , fromText
     , encodeString

--- a/src/Turtle/Bytes.hs
+++ b/src/Turtle/Bytes.hs
@@ -53,8 +53,6 @@ import Data.Monoid
 import Data.Streaming.Zlib (Inflate, Popper, PopperRes(..), WindowBits(..))
 import Data.Text (Text)
 import Data.Text.Encoding (Decoding(..))
-import Filesystem.Path (FilePath)
-import Prelude hiding (FilePath)
 import System.Exit (ExitCode(..))
 import System.IO (Handle)
 import Turtle.Internal (ignoreSIGPIPE)

--- a/src/Turtle/Format.hs
+++ b/src/Turtle/Format.hs
@@ -74,9 +74,8 @@ import Data.String (IsString(..))
 import Data.Text (Text, pack)
 import Data.Time (UTCTime)
 import Data.Word
-import Filesystem.Path.CurrentOS (FilePath, toText)
 import Numeric (showEFloat, showFFloat, showGFloat, showHex, showOct)
-import Prelude hiding ((.), id, FilePath)
+import Prelude hiding ((.), id)
 import qualified System.IO as IO
 import Turtle.Line (Line)
 
@@ -215,9 +214,9 @@ s = makeFormat id
 l :: Format r (Line -> r)
 l = makeFormat Turtle.Line.lineToText
 
--- | `Format` a `Filesystem.Path.CurrentOS.FilePath` into `Text`
+-- | `Format` a `FilePath` into `Text`
 fp :: Format r (FilePath -> r)
-fp = makeFormat (\fpath -> either id id (toText fpath))
+fp = makeFormat pack
 
 -- | `Format` a `UTCTime` into `Text`
 utc :: Format r (UTCTime -> r)

--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -32,6 +32,7 @@ toText = Right . Text.pack
 -- | Convert `Text` to a `FilePath`
 fromText :: Text -> FilePath
 fromText = Text.unpack
+{-# DEPRECATED fromText "Use Data.Text.unpack instead" #-}
 
 -- | Convert a `String` to a `FilePath`
 decodeString :: String -> FilePath

--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -102,8 +102,11 @@ directory path
 
 -- | Retrieves the `FilePath`'s filename component
 filename :: FilePath -> FilePath
-filename = FilePath.takeFileName
-{-# DEPRECATED filename "Use System.FilePath.takeFileName instead" #-}
+filename path
+    | result == "." || result == ".." = ""
+    | otherwise                       = result
+  where
+    result = FilePath.takeFileName path
 
 -- | Retrieve a `FilePath`'s directory name
 dirname :: FilePath -> FilePath
@@ -128,8 +131,14 @@ dirname path = loop (FilePath.splitPath path)
 
 -- | Retrieve a `FilePath`'s basename component
 basename :: FilePath -> String
-basename = FilePath.takeBaseName
-{-# DEPRECATED basename "Use System.FilePath.takeBaseName instead" #-}
+basename path =
+    case name of
+        '.' : _ -> name
+        _ ->
+            case splitExtensions name of
+                (base, _) -> base
+  where
+    name = filename path
 
 -- | Test whether a path is absolute
 absolute :: FilePath -> Bool

--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -54,7 +54,7 @@ stripPrefix prefix path = do
   where
     prefixComponents = splitExt (FilePath.splitPath prefix)
 
-    splitExt [ component ] = base : map ("." <>) exts
+    splitExt [ component ] = base : map ("." ++) exts
       where
         (base, exts) = splitExtensions component
     splitExt [ ] =
@@ -84,7 +84,7 @@ directory path
     | prefix == "" && suffix == ".." =
         "../"
     | otherwise =
-        trailingSlash (FilePath.takeDirectory prefix) <> suffix
+        trailingSlash (FilePath.takeDirectory prefix) ++ suffix
   where
     (prefix, suffix) = trailingParent path
       where

--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -1,10 +1,14 @@
-module Turtle.Internal
-    ( ignoreSIGPIPE
-    ) where
+module Turtle.Internal where
 
 import Control.Exception (handle, throwIO)
+import Data.Text (Text)
 import Foreign.C.Error (Errno(..), ePIPE)
 import GHC.IO.Exception (IOErrorType(..), IOException(..))
+
+import qualified Data.List as List
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text.IO
+import qualified System.FilePath as FilePath
 
 ignoreSIGPIPE :: IO () -> IO ()
 ignoreSIGPIPE = handle (\e -> case e of
@@ -14,3 +18,109 @@ ignoreSIGPIPE = handle (\e -> case e of
         | Errno ioe == ePIPE -> return ()
     _ -> throwIO e
     )
+
+{-| Convert a `FilePath` to human-readable `Text`
+
+    Note that even though the type says `Either` this utility actually always
+    succeeds and returns a `Right` value.  The only reason for the `Either` is
+    compatibility with the old type from the @system-filepath@ package.
+-}
+toText :: FilePath -> Either Text Text
+toText = Right . Text.pack
+{-# DEPRECATED toText "Use Data.Text.pack instead" #-}
+
+-- | Convert `Text` to a `FilePath`
+fromText :: Text -> FilePath
+fromText = Text.unpack
+
+-- | Convert a `String` to a `FilePath`
+decodeString :: String -> FilePath
+decodeString = id
+{-# DEPRECATED decodeString "Use id instead" #-}
+
+-- | Convert a `FilePath` to a `String`
+encodeString :: FilePath -> String
+encodeString = id
+{-# DEPRECATED encodeString "Use id instead" #-}
+
+-- | Remove a prefix from a path
+stripPrefix :: FilePath -> FilePath -> Maybe FilePath
+stripPrefix prefix path = do
+    suffix <- List.stripPrefix prefixComponents pathComponents
+
+    return (FilePath.joinPath suffix)
+  where
+    prefixComponents = FilePath.splitPath prefix
+
+    pathComponents = FilePath.splitPath path
+
+-- | Read in a file as `Text`
+readTextFile :: FilePath -> IO Text
+readTextFile = Text.IO.readFile
+{-# DEPRECATED readTextFile "Use Data.Text.IO.readFile instead" #-}
+
+-- | Write out a file as `Text`
+writeTextFile :: FilePath -> Text -> IO ()
+writeTextFile = Text.IO.writeFile
+{-# DEPRECATED writeTextFile "Use Data.Text.IO.writeFile instead" #-}
+
+-- | Retrieves the `FilePath`'s root
+root :: FilePath -> FilePath
+root = fst . FilePath.splitDrive
+
+-- | Retrieves the `FilePath`'s directory
+directory :: FilePath -> FilePath
+directory = FilePath.takeDirectory
+{-# DEPRECATED directory "Use System.FilePath.takeDirectory instead" #-}
+
+-- | Retrieves the `FilePath`'s filename component
+filename :: FilePath -> FilePath
+filename = FilePath.takeFileName
+{-# DEPRECATED filename "Use System.FilePath.takeFileName instead" #-}
+
+-- | Retrieve a `FilePath`'s directory name
+dirname :: FilePath -> FilePath
+dirname path = FilePath.joinPath (loop (FilePath.splitPath path))
+  where
+    loop [ x, _ ] = [ x ]
+    loop [ _ ]    = [ ]
+    loop [ ]      = [ ]
+    loop (_ : xs) = loop xs
+
+-- | Retrieve a `FilePath`'s basename component
+basename :: FilePath -> String
+basename = FilePath.takeBaseName
+{-# DEPRECATED basename "Use System.FilePath.takeBaseName instead" #-}
+
+-- | Test whether a path is absolute
+absolute :: FilePath -> Bool
+absolute = FilePath.isAbsolute
+{-# DEPRECATED absolute "Use System.FilePath.isAbsolute instead" #-}
+
+-- | Test whether a path is relative
+relative :: FilePath -> Bool
+relative = FilePath.isRelative
+{-# DEPRECATED relative "Use System.FilePath.isRelative instead" #-}
+
+-- | Split a `FilePath` into its components
+splitDirectories :: FilePath -> [FilePath]
+splitDirectories = FilePath.splitPath
+{-# DEPRECATED splitDirectories "Use System.FilePath.splitPath instead" #-}
+
+-- | Get a `FilePath`'s last extension, or `Nothing` if it has no extension
+extension :: FilePath -> Maybe String
+extension path
+    | suffix == "" = Nothing
+    | otherwise    = Just suffix
+  where
+    suffix = FilePath.takeExtension path
+{-# DEPRECATED extension "Use System.FilePath.takeExtension instead" #-}
+
+-- | Split a `FilePath` on its extension
+splitExtension :: FilePath -> (String, Maybe String)
+splitExtension path
+    | suffix == "" = (prefix, Nothing)
+    | otherwise    = (prefix, Just suffix)
+  where
+    (prefix, suffix) = FilePath.splitExtension path
+{-# DEPRECATED splitExtension "Use System.FilePath.splitExtension instead" #-}

--- a/src/Turtle/Options.hs
+++ b/src/Turtle/Options.hs
@@ -83,9 +83,7 @@ import Data.Text (Text)
 import Data.Optional
 import Control.Applicative
 import Control.Monad.IO.Class
-import Filesystem.Path.CurrentOS (FilePath, fromText)
 import Options.Applicative (Parser)
-import Prelude hiding (FilePath)
 import Text.PrettyPrint.ANSI.Leijen (Doc, displayS, renderCompact)
 import Turtle.Line (Line)
 
@@ -237,7 +235,7 @@ optLine = opt Turtle.Line.textToLine
 
 -- | Parse a `FilePath` value as a flag-based option
 optPath :: ArgName -> ShortName -> Optional HelpMessage -> Parser FilePath
-optPath argName short msg = fmap fromText (optText argName short msg)
+optPath argName short msg = fmap Text.unpack (optText argName short msg)
 
 {- | Build a positional argument parser for any type by providing a
     `Text`-parsing function
@@ -277,7 +275,7 @@ argLine = arg Turtle.Line.textToLine
 
 -- | Parse a `FilePath` as a positional argument
 argPath :: ArgName -> Optional HelpMessage -> Parser FilePath
-argPath argName msg = fmap fromText (argText argName msg)
+argPath argName msg = fmap Text.unpack (argText argName msg)
 
 argParseToReadM :: (Text -> Maybe a) -> Opts.ReadM a
 argParseToReadM f = do

--- a/test/cptree.hs
+++ b/test/cptree.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Turtle
-import Filesystem.Path.CurrentOS ()
 import System.IO.Temp (withSystemTempDirectory)
 import qualified Control.Monad.Fail as Fail
 import Control.Monad (unless)

--- a/test/system-filepath.hs
+++ b/test/system-filepath.hs
@@ -1,0 +1,163 @@
+{-# Language CPP #-}
+{-# Options_GHC -Wno-deprecations #-}
+
+module Main (main) where
+
+import System.FilePath (splitExtensions)
+import Test.Tasty
+import Test.Tasty.HUnit
+import Turtle
+
+main :: IO ()
+main = defaultMain $ testGroup "system-filepath tests"
+    [ test_Root
+    , test_Directory
+    , test_StripPrefix
+    , test_Filename
+    , test_Dirname
+    , test_Basename
+    , test_Absolute
+    , test_Relative
+    , test_SplitDirectories
+    , test_SplitExtension
+    ]
+
+test_Root :: TestTree
+test_Root = testCase "root" $ do
+    "" @=? root ""
+    "/" @=? root "/"
+    "" @=? root "foo"
+    "/" @=? root "/foo"
+
+test_Directory :: TestTree
+test_Directory = testCase "directory" $ do
+    "./" @=? directory ""
+    "/" @=? directory "/"
+    "/foo/" @=? directory "/foo/bar"
+    "/foo/bar/" @=? directory "/foo/bar/"
+    "./" @=? directory "."
+    "../" @=? directory ".."
+    "../" @=? directory "../foo"
+    "../foo/" @=? directory "../foo/"
+    "./" @=? directory "foo"
+    "foo/" @=? directory "foo/bar"
+
+test_Filename :: TestTree
+test_Filename = testCase "filename" $ do
+    "" @=? filename ""
+    "" @=? filename "/"
+    "" @=? filename "/foo/"
+    "bar" @=? filename "/foo/bar"
+    "bar.txt" @=? filename "/foo/bar.txt"
+
+test_Dirname :: TestTree
+test_Dirname = testCase "dirname" $ do
+    "" @=? dirname ""
+    "" @=? dirname "/"
+    "" @=? dirname "foo"
+    "foo" @=? dirname "foo/bar"
+    "bar" @=? dirname "foo/bar/"
+    "bar" @=? dirname "foo/bar/baz.txt"
+
+    -- the directory name will be re-parsed to a file name.
+    let dirnameExts q = extensions (dirname q)
+    ["d"] @=? dirnameExts "foo.d/bar"
+
+    -- reparsing preserves good/bad encoding state
+    ["\xB1", "\x76A"] @=? dirnameExts "foo.\xB1.\xDD\xAA/bar"
+
+test_Basename :: TestTree
+test_Basename = testCase "basename" $ do
+
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+    "bar" @=? basename "c:\\foo\\bar"
+    "bar" @=? basename "c:\\foo\\bar.txt"
+#else
+    "bar" @=? basename "/foo/bar"
+    "bar" @=? basename "/foo/bar.txt"
+#endif
+
+test_Absolute :: TestTree
+test_Absolute = testCase "absolute" $ do
+    let myAssert q = assertBool ("absolute " ++ show q) $ absolute q
+    let myAssert' q = assertBool ("not $ absolute " ++ show q) $ not $ absolute q
+
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+    myAssert "c:\\"
+    myAssert "c:\\foo\\bar"
+    myAssert' ""
+    myAssert' "foo\\bar"
+    myAssert' "\\foo\\bar"
+#else
+    myAssert "/"
+    myAssert "/foo/bar"
+    myAssert' ""
+    myAssert' "foo/bar"
+#endif
+
+
+test_Relative :: TestTree
+test_Relative = testCase "relative" $ do
+    let myAssert q = assertBool ("relative " ++ show q) $ relative q
+    let myAssert' q = assertBool ("not $ relative " ++ show q) $ not $ relative q
+
+#if defined(mingw32_HOST_OS) || defined(__MINGW32__)
+    myAssert' "c:\\"
+    myAssert' "c:\\foo\\bar"
+    myAssert ""
+    myAssert "foo\\bar"
+    myAssert' "\\foo\\bar"
+#else
+    myAssert' "/"
+    myAssert' "/foo/bar"
+    myAssert ""
+    myAssert "foo/bar"
+#endif
+
+test_StripPrefix :: TestTree
+test_StripPrefix = testCase "stripPrefix" $ do
+    Just "" @=? stripPrefix "" ""
+    Just "/" @=? stripPrefix "" "/"
+    Just "" @=? stripPrefix "/" "/"
+    Just "foo" @=? stripPrefix "/" "/foo"
+    Just "foo/bar" @=? stripPrefix "/" "/foo/bar"
+    Just "bar" @=? stripPrefix "/foo/" "/foo/bar"
+    Just "bar/baz" @=? stripPrefix "/foo/" "/foo/bar/baz"
+    Just ".txt" @=? stripPrefix "/foo/bar" "/foo/bar.txt"
+    Just ".gz" @=? stripPrefix "/foo/bar.txt" "/foo/bar.txt.gz"
+
+    -- Test ignoring non-matching prefixes
+    Nothing @=? stripPrefix "/foo" "/foo/bar"
+    Nothing @=? stripPrefix "/foo/bar/baz" "/foo"
+    Nothing @=? stripPrefix "/foo/baz/" "/foo/bar/qux"
+    Nothing @=? stripPrefix "/foo/bar/baz" "/foo/bar/qux"
+    Nothing @=? stripPrefix "/foo/bar/baz" "/foo/bar/qux"
+
+test_SplitDirectories :: TestTree
+test_SplitDirectories = testCase "splitDirectories" $ do
+    [] @=? splitDirectories ""
+    ["/"] @=? splitDirectories "/"
+    ["/", "a"] @=? splitDirectories "/a"
+    ["/", "ab/", "cd"] @=? splitDirectories "/ab/cd"
+    ["/", "ab/", "cd/"] @=? splitDirectories "/ab/cd/"
+    ["ab/", "cd"] @=? splitDirectories "ab/cd"
+    ["ab/", "cd/"] @=? splitDirectories "ab/cd/"
+    ["ab/", "cd.txt"] @=? splitDirectories "ab/cd.txt"
+    ["ab/", "cd/", ".txt"] @=? splitDirectories "ab/cd/.txt"
+    ["ab/", ".", "cd"] @=? splitDirectories "ab/./cd"
+
+test_SplitExtension :: TestTree
+test_SplitExtension = testCase "splitExtension" $ do
+    ("", Nothing) @=? splitExtension ""
+    ("foo", Nothing) @=? splitExtension "foo"
+    ("foo", Just "") @=? splitExtension "foo."
+    ("foo", Just "a") @=? splitExtension "foo.a"
+    ("foo.a/", Nothing) @=? splitExtension "foo.a/"
+    ("foo.a/bar", Nothing) @=? splitExtension "foo.a/bar"
+    ("foo.a/bar", Just "b") @=? splitExtension "foo.a/bar.b"
+    ("foo.a/bar.b", Just "c") @=? splitExtension "foo.a/bar.b.c"
+
+extensions :: FilePath -> [String]
+extensions p = case splitExtensions p of
+    (p', "") -> [p']
+    (p', q ) -> extensions p' ++ [q]

--- a/test/system-filepath.hs
+++ b/test/system-filepath.hs
@@ -44,6 +44,8 @@ test_Directory = testCase "directory" $ do
 test_Filename :: TestTree
 test_Filename = testCase "filename" $ do
     "" @=? filename ""
+    "" @=? filename "."
+    "" @=? filename ".."
     "" @=? filename "/"
     "" @=? filename "/foo/"
     "bar" @=? filename "/foo/bar"
@@ -64,6 +66,12 @@ test_Dirname = testCase "dirname" $ do
 
 test_Basename :: TestTree
 test_Basename = testCase "basename" $ do
+    "" @=? basename ".."
+    "" @=? basename "/"
+    "" @=? basename "."
+    ".txt" @=? basename ".txt"
+    "foo" @=? basename "foo.txt"
+    "bar" @=? basename "foo/bar.txt"
 
 #if defined(mingw32_HOST_OS) || defined(__MINGW32__)
     "bar" @=? basename "c:\\foo\\bar"

--- a/test/system-filepath.hs
+++ b/test/system-filepath.hs
@@ -62,9 +62,6 @@ test_Dirname = testCase "dirname" $ do
     let dirnameExts q = snd (splitExtensions (dirname q))
     ["d"] @=? dirnameExts "foo.d/bar"
 
-    -- reparsing preserves good/bad encoding state
-    ["\xB1", "\x76A"] @=? dirnameExts "foo.\xB1.\xDD\xAA/bar"
-
 test_Basename :: TestTree
 test_Basename = testCase "basename" $ do
 

--- a/test/system-filepath.hs
+++ b/test/system-filepath.hs
@@ -127,7 +127,6 @@ test_StripPrefix = testCase "stripPrefix" $ do
     Nothing @=? stripPrefix "/foo/bar/baz" "/foo"
     Nothing @=? stripPrefix "/foo/baz/" "/foo/bar/qux"
     Nothing @=? stripPrefix "/foo/bar/baz" "/foo/bar/qux"
-    Nothing @=? stripPrefix "/foo/bar/baz" "/foo/bar/qux"
 
 test_SplitDirectories :: TestTree
 test_SplitDirectories = testCase "splitDirectories" $ do

--- a/test/system-filepath.hs
+++ b/test/system-filepath.hs
@@ -3,7 +3,6 @@
 
 module Main (main) where
 
-import System.FilePath (splitExtensions)
 import Test.Tasty
 import Test.Tasty.HUnit
 import Turtle
@@ -60,7 +59,7 @@ test_Dirname = testCase "dirname" $ do
     "bar" @=? dirname "foo/bar/baz.txt"
 
     -- the directory name will be re-parsed to a file name.
-    let dirnameExts q = extensions (dirname q)
+    let dirnameExts q = snd (splitExtensions (dirname q))
     ["d"] @=? dirnameExts "foo.d/bar"
 
     -- reparsing preserves good/bad encoding state
@@ -144,7 +143,7 @@ test_SplitDirectories = testCase "splitDirectories" $ do
     ["ab/", "cd/"] @=? splitDirectories "ab/cd/"
     ["ab/", "cd.txt"] @=? splitDirectories "ab/cd.txt"
     ["ab/", "cd/", ".txt"] @=? splitDirectories "ab/cd/.txt"
-    ["ab/", ".", "cd"] @=? splitDirectories "ab/./cd"
+    ["ab/", "./", "cd"] @=? splitDirectories "ab/./cd"
 
 test_SplitExtension :: TestTree
 test_SplitExtension = testCase "splitExtension" $ do
@@ -156,8 +155,3 @@ test_SplitExtension = testCase "splitExtension" $ do
     ("foo.a/bar", Nothing) @=? splitExtension "foo.a/bar"
     ("foo.a/bar", Just "b") @=? splitExtension "foo.a/bar.b"
     ("foo.a/bar.b", Just "c") @=? splitExtension "foo.a/bar.b.c"
-
-extensions :: FilePath -> [String]
-extensions p = case splitExtensions p of
-    (p', "") -> [p']
-    (p', q ) -> extensions p' ++ [q]

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -69,7 +69,7 @@ Library
         containers           >= 0.5.0.0 && < 0.7 ,
         directory            >= 1.3.1.0 && < 1.4 ,
         exceptions           >= 0.4     && < 0.11,
-        filepath             >= 1.4.2.1 && < 1.5 ,
+        filepath             >= 1.4.1.2 && < 1.5 ,
         foldl                >= 1.1     && < 1.5 ,
         hostname                           < 1.1 ,
         managed              >= 1.0.3   && < 1.1 ,
@@ -143,6 +143,19 @@ test-suite cptree
         base   >= 4 && < 5,
         temporary,
         filepath >= 0.4,
+        turtle
+
+test-suite system-filepath-tests
+    Type: exitcode-stdio-1.0
+    HS-Source-Dirs: test
+    Main-Is: system-filepath.hs
+    GHC-Options: -Wall -threaded
+    Default-Language: Haskell2010
+    Build-Depends:
+        base,
+        filepath,
+        tasty >=1.4 && <1.5,
+        tasty-hunit >=0.10 && <0.11,
         turtle
 
 benchmark bench

--- a/turtle.cabal
+++ b/turtle.cabal
@@ -29,7 +29,7 @@ Description: @turtle@ is a reimplementation of the Unix command line environment
     .
     * Formatting: Type-safe @printf@-style text formatting
     .
-    * Modern: Supports @text@ and @system-filepath@
+    * Modern: Supports @text@
     .
     Read "Turtle.Tutorial" for a detailed tutorial or "Turtle.Prelude" for a
     quick-start guide
@@ -69,12 +69,11 @@ Library
         containers           >= 0.5.0.0 && < 0.7 ,
         directory            >= 1.3.1.0 && < 1.4 ,
         exceptions           >= 0.4     && < 0.11,
+        filepath             >= 1.4.2.1 && < 1.5 ,
         foldl                >= 1.1     && < 1.5 ,
         hostname                           < 1.1 ,
         managed              >= 1.0.3   && < 1.1 ,
         process              >= 1.0.1.1 && < 1.7 ,
-        system-filepath      >= 0.3.1   && < 0.5 ,
-        system-fileio        >= 0.2.1   && < 0.4 ,
         stm                                < 2.6 ,
         streaming-commons                  < 0.3 ,
         temporary                          < 1.4 ,
@@ -143,7 +142,7 @@ test-suite cptree
     Build-Depends:
         base   >= 4 && < 5,
         temporary,
-        system-filepath >= 0.4,
+        filepath >= 0.4,
         turtle
 
 benchmark bench


### PR DESCRIPTION
… in favor of the `filepath` / `directory` packages and
the `FilePath` type from `base`

Fixes https://github.com/Gabriella439/turtle/issues/54

This is a breaking change for the following reasons:

* All of the utilities now work with the `FilePath` type from
  `base` insead of the `FilePath` type from `system-filepath`

* The new API doesn't provide equivalent replacements for these
  old utilities:

  * `collapse`
  * `parent`
  * `commonPrefix`

* The behavior of the new utilities might be subtly different

  … although I took pains to try to mirror the old behavior as closely
  as possible, so if there is a difference in behavior it's not
  intentional.