### PR TITLE
Restore old `parent` utility

### DIFF
--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -136,6 +136,7 @@ import System.Exit (ExitCode(..))
 import Turtle.Internal
     ( root
     , directory
+    , parent
     , filename
     , dirname
     , basename

--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -5,6 +5,7 @@ import Control.Exception (handle, throwIO)
 import Data.Text (Text)
 import Foreign.C.Error (Errno(..), ePIPE)
 import GHC.IO.Exception (IOErrorType(..), IOException(..))
+import System.FilePath ((</>))
 
 import qualified Data.List as List
 import qualified Data.Text as Text
@@ -77,6 +78,27 @@ writeTextFile = Text.IO.writeFile
 -- | Retrieves the `FilePath`'s root
 root :: FilePath -> FilePath
 root = fst . FilePath.splitDrive
+
+-- | Retrieves the `FilePath`'s parent directory
+parent :: FilePath -> FilePath
+parent path = prefix </> suffix
+  where
+    (drive, rest) = FilePath.splitDrive path
+
+    components = loop (FilePath.splitPath rest)
+
+    prefix =
+        case components of
+            "./"  : _ -> drive
+            "../" : _ -> drive
+            _ | null drive -> "./"
+              | otherwise  -> drive
+
+    suffix = FilePath.joinPath components
+
+    loop [ _ ]    = [ ]
+    loop [ ]      = [ ]
+    loop (c : cs) = c : loop cs
 
 -- | Retrieves the `FilePath`'s directory
 directory :: FilePath -> FilePath

--- a/test/system-filepath.hs
+++ b/test/system-filepath.hs
@@ -11,6 +11,7 @@ main :: IO ()
 main = defaultMain $ testGroup "system-filepath tests"
     [ test_Root
     , test_Directory
+    , test_Parent
     , test_StripPrefix
     , test_Filename
     , test_Dirname
@@ -40,6 +41,30 @@ test_Directory = testCase "directory" $ do
     "../foo/" @=? directory "../foo/"
     "./" @=? directory "foo"
     "foo/" @=? directory "foo/bar"
+
+test_Parent :: TestTree
+test_Parent = testCase "parent" $ do
+    -- The behavior in the presence of `.` / `..` is messed up, but that's how
+    -- the old system-filepath package worked, so we're preserving that for
+    -- backwards compatibility (for now)
+    "./" @=? parent ""
+    "./" @=? parent "."
+    "./" @=? parent ".."
+    "/" @=? parent "/.."
+    "/" @=? parent "/."
+    "./" @=? parent "./."
+    "./" @=? parent "./.."
+    "../" @=? parent "../.."
+    "../" @=? parent "../."
+
+    "/" @=? parent "/"
+    "./" @=? parent "foo"
+    "./" @=? parent "./foo"
+    "./foo/" @=? parent "foo/bar"
+    "./foo/" @=? parent "foo/bar/"
+    "./foo/" @=? parent "./foo/bar"
+    "/" @=? parent "/foo"
+    "/foo/" @=? parent "/foo/bar"
 
 test_Filename :: TestTree
 test_Filename = testCase "filename" $ do


### PR DESCRIPTION
I pushed a bit harder on getting the old `parent` utility to
work, even though its behavior is a bit confusing in the presence
of `.` and `..`