### PR TITLE
Restore `collapse` utility

### DIFF
--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -143,6 +143,7 @@ import Turtle.Internal
     , absolute
     , relative
     , stripPrefix
+    , collapse
     , splitDirectories
     , extension
     , splitExtension

--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -65,6 +65,11 @@ stripPrefix prefix path = do
 
     pathComponents = splitExt (FilePath.splitPath path)
 
+-- | Normalise a path
+collapse :: FilePath -> FilePath
+collapse = FilePath.normalise
+{-# DEPRECATED collapse "Use System.FilePath.normalise instead" #-}
+
 -- | Read in a file as `Text`
 readTextFile :: FilePath -> IO Text
 readTextFile = Text.IO.readFile


### PR DESCRIPTION
It is now implemented in terms of the `normalise` function

This behavior is *not* the same as the old `collapse` utility.
Specifically, the way they handle `..` is different, but I decided
that the difference in behavior is an improvement and therefore
opted to not try to exactly preserve the old behavior.