### PR TITLE
Restore old `commonPrefix` utility

### DIFF
--- a/src/Turtle.hs
+++ b/src/Turtle.hs
@@ -127,7 +127,6 @@ import System.FilePath
     , hasExtension
     , isAbsolute
     , isRelative
-    , splitPath
     , (</>)
     , (<.>)
     )
@@ -142,6 +141,7 @@ import Turtle.Internal
     , basename
     , absolute
     , relative
+    , commonPrefix
     , stripPrefix
     , collapse
     , splitDirectories


### PR DESCRIPTION
… and fix the behavior of `splitDirectories` along the way

I also added several tests to cover holes in the testing
around the handling of `.` and `..`

I also removed `splitPath` from the re-export list since
`splitDirectories` is no longer deprecated (and therefore we
don't need to re-export `splitPath` as its replacement)