### PR TITLE
Fix `commonPrefix` and `stripPrefix`

### DIFF
--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -51,12 +51,16 @@ commonPrefix :: [FilePath] -> FilePath
 commonPrefix [ ] = mempty
 commonPrefix (path : paths) = foldr longestPathPrefix path paths
   where
-    longestPathPrefix left right =
-        FilePath.joinPath (longestPrefix leftComponents rightComponents)
+    longestPathPrefix left right
+        | leftComponents == rightComponents =
+               FilePath.joinPath leftComponents
+            <> mconcat (longestPrefix leftExtensions rightExtensions)
+        | otherwise =
+           FilePath.joinPath (longestPrefix leftComponents rightComponents)
       where
-        leftComponents = splitExt (splitDirectories left)
+        (leftComponents, leftExtensions)  = splitExt (splitDirectories left)
 
-        rightComponents = splitExt (splitDirectories right)
+        (rightComponents, rightExtensions) = splitExt (splitDirectories right)
 
 longestPrefix :: Eq a => [a] -> [a] -> [a]
 longestPrefix (l : ls) (r : rs)
@@ -66,23 +70,30 @@ longestPrefix _ _ = [ ]
 -- | Remove a prefix from a path
 stripPrefix :: FilePath -> FilePath -> Maybe FilePath
 stripPrefix prefix path = do
-    suffix <- List.stripPrefix prefixComponents pathComponents
+    componentSuffix <- List.stripPrefix prefixComponents pathComponents
 
-    return (FilePath.joinPath suffix)
+    if null componentSuffix
+        then do
+            prefixSuffix <- List.stripPrefix prefixExtensions pathExtensions
+
+            return (mconcat prefixSuffix)
+        else do
+            return (FilePath.joinPath componentSuffix <> mconcat pathExtensions)
   where
-    prefixComponents = splitExt (splitDirectories prefix)
+    (prefixComponents, prefixExtensions) = splitExt (splitDirectories prefix)
 
-    pathComponents = splitExt (splitDirectories path)
+    (pathComponents, pathExtensions) = splitExt (splitDirectories path)
 
 -- Internal helper function for `stripPrefix` and `commonPrefix`
-splitExt :: [FilePath] -> [FilePath]
-splitExt [ component ] = base : map ("." ++) exts
+splitExt :: [FilePath] -> ([FilePath], [String])
+splitExt [ component ] = ([ base ], map ("." ++) exts)
   where
     (base, exts) = splitExtensions component
 splitExt [ ] =
-    [ ]
-splitExt (component : components) =
-    component : splitExt components
+    ([ ], [ ])
+splitExt (component : components) = (component : base, exts)
+  where
+    (base, exts) = splitExt components
 
 -- | Normalise a path
 collapse :: FilePath -> FilePath

--- a/src/Turtle/Internal.hs
+++ b/src/Turtle/Internal.hs
@@ -54,7 +54,7 @@ commonPrefix (path : paths) = foldr longestPathPrefix path paths
     longestPathPrefix left right
         | leftComponents == rightComponents =
                FilePath.joinPath leftComponents
-            <> mconcat (longestPrefix leftExtensions rightExtensions)
+            ++ mconcat (longestPrefix leftExtensions rightExtensions)
         | otherwise =
            FilePath.joinPath (longestPrefix leftComponents rightComponents)
       where
@@ -78,7 +78,7 @@ stripPrefix prefix path = do
 
             return (mconcat prefixSuffix)
         else do
-            return (FilePath.joinPath componentSuffix <> mconcat pathExtensions)
+            return (FilePath.joinPath componentSuffix ++ mconcat pathExtensions)
   where
     (prefixComponents, prefixExtensions) = splitExt (splitDirectories prefix)
 

--- a/test/system-filepath.hs
+++ b/test/system-filepath.hs
@@ -152,6 +152,7 @@ test_CommonPrefix = testCase "commonPrefix" $ do
     "./" @=? commonPrefix [".", "."]
     "" @=? commonPrefix [".", ".."]
     "foo/" @=? commonPrefix ["foo/bar", "foo/baz"]
+    "foo/a.b" @=? commonPrefix ["foo/a.b.c", "foo/a.b.d"]
     "" @=? commonPrefix ["foo/", "bar/"]
 
 test_StripPrefix :: TestTree
@@ -160,6 +161,8 @@ test_StripPrefix = testCase "stripPrefix" $ do
     Just "/" @=? stripPrefix "" "/"
     Just "" @=? stripPrefix "/" "/"
     Just "foo" @=? stripPrefix "/" "/foo"
+    Just "foo" @=? stripPrefix "./" "./foo"
+    Just "foo.ext" @=? stripPrefix "./" "./foo.ext"
     Just "foo/bar" @=? stripPrefix "/" "/foo/bar"
     Just "bar" @=? stripPrefix "/foo/" "/foo/bar"
     Just "bar/baz" @=? stripPrefix "/foo/" "/foo/bar/baz"


### PR DESCRIPTION
They were both handling paths with extensions incorrectly.  For
example:

```haskell
>>> stripPrefix "./" "./foo.bar"
Just "foo/.bar"
```