### PR TITLE
mark up license in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,20 @@ available tools to minimally match `coreutils`.
 
 ## License (BSD 3-clause)
 
-Copyright (c) 2017 Gabriella Gonzalez
+Copyright (c) 2017 Gabriella Gonzalez\
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-    * Neither the name of Gabriella Gonzalez nor the names of other contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
+
+   * Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+   * Neither the name of Gabriella Gonzalez nor the names of other contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
so that GitHub renders it correctly

(An alternative would be to wrap it in ` ``` ` lines, so that it'd be rendered as a preformatted verbatim ("code") block. But monospace fonts don't make prose very readable, so I'd prefer the change I propose here.)